### PR TITLE
Add TFC Flowers to Forestry Bees

### DIFF
--- a/config/forestry/apiculture.cfg
+++ b/config/forestry/apiculture.cfg
@@ -19,6 +19,7 @@ beekeeping {
                 minecraft:double_plant:4
                 minecraft:double_plant:5
                 terrafirmacraft:Flowers
+                terrafirmacraft:Flowers2
              >
 
             # Plantable flowers are placed by bees. All plantable flowers are automatically accepted flowers. Format is 'modid:name:meta', one per line. The format for wildcard  metadata is 'modid:name'.
@@ -33,6 +34,8 @@ beekeeping {
                 minecraft:red_flower:6
                 minecraft:red_flower:7
                 minecraft:red_flower:8
+                terrafirmacraft:Flowers
+                terrafirmacraft:Flowers2
              >
         }
 
@@ -51,10 +54,12 @@ beekeeping {
             # Accepted flowers allow bees to work. Format is 'modid:name:meta', one per line. The format for wildcard  metadata is 'modid:name'.
             S:accepted <
                 minecraft:cactus
+                terrafirmacraft:Cactus
              >
 
             # Plantable flowers are placed by bees. All plantable flowers are automatically accepted flowers. Format is 'modid:name:meta', one per line. The format for wildcard  metadata is 'modid:name'.
             S:plantable <
+                terrafirmacraft:Cactus
              >
         }
 
@@ -68,6 +73,7 @@ beekeeping {
             S:plantable <
                 minecraft:brown_mushroom:0
                 minecraft:red_mushroom:0
+                terrafirmacraft:Fungi
              >
         }
 
@@ -87,10 +93,14 @@ beekeeping {
             S:accepted <
                 minecraft:vine
                 minecraft:tallgrass
+                terrafirmacraft:Vine
+                terrafirmacraft:TallGrass:1
              >
 
             # Plantable flowers are placed by bees. All plantable flowers are automatically accepted flowers. Format is 'modid:name:meta', one per line. The format for wildcard  metadata is 'modid:name'.
             S:plantable <
+                terrafirmacraft:Vine
+                terrafirmacraft:TallGrass:1
              >
         }
 
@@ -101,6 +111,8 @@ beekeeping {
                 minecraft:double_plant:1
                 minecraft:double_plant:4
                 minecraft:double_plant:5
+                terrafirmacraft:Flowers
+                terrafirmacraft:Flowers2
              >
 
             # Plantable flowers are placed by bees. All plantable flowers are automatically accepted flowers. Format is 'modid:name:meta', one per line. The format for wildcard  metadata is 'modid:name'.
@@ -115,6 +127,8 @@ beekeeping {
                 minecraft:red_flower:6
                 minecraft:red_flower:7
                 minecraft:red_flower:8
+                terrafirmacraft:Flowers
+                terrafirmacraft:Flowers2
              >
         }
 
@@ -122,10 +136,12 @@ beekeeping {
             # Accepted flowers allow bees to work. Format is 'modid:name:meta', one per line. The format for wildcard  metadata is 'modid:name'.
             S:accepted <
                 minecraft:wheat
+                terrafirmacraft:TallGrass:0
              >
 
             # Plantable flowers are placed by bees. All plantable flowers are automatically accepted flowers. Format is 'modid:name:meta', one per line. The format for wildcard  metadata is 'modid:name'.
             S:plantable <
+                terrafirmacraft:TallGrass:0
              >
         }
 
@@ -134,6 +150,7 @@ beekeeping {
             S:accepted <
                 minecraft:pumpkin_stem
                 minecraft:melon_stem
+                terrafirmacraft:Pumpkin
              >
 
             # Plantable flowers are placed by bees. All plantable flowers are automatically accepted flowers. Format is 'modid:name:meta', one per line. The format for wildcard  metadata is 'modid:name'.


### PR DESCRIPTION
This change allows all TFC flowers to work with Forestry with the same mechanics and functionality as stock Minecraft.

* Added Flowers2 to be accepted flowers for Normal (Meadows, Forest) and Snow (Wintry) Bees (These include Rose, Blue Orchid, Allium, Houstonia, Tulips, Daisy)
* Added TFC Cactus to be usable by the Desert (Modest) bees
* Added TFC Jungle Vines and TFC Ferns to be usable by the Jungle (Tropical) bees

* Added the ability for all bees to plant their accepted TFC flowers:
  * Normal (Forest and Meadow) and Snow (Wintry) bees can plant all Flowers and Flowers2
  * Desert (Modest) bees can plant TFC Cactus
  * Swamp (Marshy) bees can plant TFC Mushrooms
  * Jungle (Tropical) bees can plant TFC Vines and TFC Ferns