### PR TITLE
Change Vulcanizing Agents for More Realism

### DIFF
--- a/scripts/TFC.zs
+++ b/scripts/TFC.zs
@@ -197,10 +197,10 @@ mods.Terrafirmacraft.Quern.addRecipe(<minecraft:redstone> * 4, <terrafirmacraft:
 // Update Vulcanization Agents to be more realistic as well as not completely dependent on Chalk
 // Add recipes for Zinc Dust in the Quern
 mods.Terrafirmacraft.Quern.addRecipe(<techreborn:smallDust:87>*2, <terrafirmacraft:item.Zinc Ingot>);    // 2x Small Zinc Dust from Zinc Ingot
-mods.Terrafirmacraft.Quern.addRecipe(<techreborn:smallDust:87>, <terrafirmacraft:item.Small Ore:8>*5);   // Small Zinc Dust from 5x Small Garnierite
-mods.Terrafirmacraft.Quern.addRecipe(<techreborn:smallDust:87>, <terrafirmacraft:item.Ore:57>*3);        // Small Zinc Dust from 3x Poor Garnierite
-mods.Terrafirmacraft.Quern.addRecipe(<techreborn:smallDust:87>, <terrafirmacraft:item.Ore:8>*2);         // Small Zinc Dust from 2x Normal Garnierite
-mods.Terrafirmacraft.Quern.addRecipe(<techreborn:smallDust:87>, <terrafirmacraft:item.Ore:43>);          // Small Zinc Dust from Rich Garnierite
+mods.Terrafirmacraft.Quern.addRecipe(<techreborn:smallDust:87>, <terrafirmacraft:item.Small Ore:12>*5);   // Small Zinc Dust from 5x Small Sphalerite
+mods.Terrafirmacraft.Quern.addRecipe(<techreborn:smallDust:87>, <terrafirmacraft:item.Ore:61>*3);        // Small Zinc Dust from 3x Poor Sphalerite
+mods.Terrafirmacraft.Quern.addRecipe(<techreborn:smallDust:87>, <terrafirmacraft:item.Ore:12>*2);         // Small Zinc Dust from 2x Normal Sphalerite
+mods.Terrafirmacraft.Quern.addRecipe(<techreborn:smallDust:87>, <terrafirmacraft:item.Ore:47>);          // Small Zinc Dust from Rich Sphalerite
 
 // Add more accurate recipe for Vulcanizing Agents using Zinc Dust
 recipes.remove(<tfctech:item.Vulcanizing Agents>);

--- a/scripts/TFC.zs
+++ b/scripts/TFC.zs
@@ -193,3 +193,17 @@ marble.add(<terrafirmacraft:StoneMMSmooth:5>);
 //
 mods.Terrafirmacraft.Quern.removeRecipe(<minecraft:redstone> * 8, <terrafirmacraft:item.Ore:28>);
 mods.Terrafirmacraft.Quern.addRecipe(<minecraft:redstone> * 4, <terrafirmacraft:item.Ore:28>);
+
+// Update Vulcanization Agents to be more realistic as well as not completely dependent on Chalk
+// Add recipes for Zinc Dust in the Quern
+mods.Terrafirmacraft.Quern.addRecipe(<techreborn:smallDust:87>*2, <terrafirmacraft:item.Zinc Ingot>);    // 2x Small Zinc Dust from Zinc Ingot
+mods.Terrafirmacraft.Quern.addRecipe(<techreborn:smallDust:87>, <terrafirmacraft:item.Small Ore:8>*5);   // Small Zinc Dust from 5x Small Garnierite
+mods.Terrafirmacraft.Quern.addRecipe(<techreborn:smallDust:87>, <terrafirmacraft:item.Ore:57>*3);        // Small Zinc Dust from 3x Poor Garnierite
+mods.Terrafirmacraft.Quern.addRecipe(<techreborn:smallDust:87>, <terrafirmacraft:item.Ore:8>*2);         // Small Zinc Dust from 2x Normal Garnierite
+mods.Terrafirmacraft.Quern.addRecipe(<techreborn:smallDust:87>, <terrafirmacraft:item.Ore:43>);          // Small Zinc Dust from Rich Garnierite
+
+// Add more accurate recipe for Vulcanizing Agents using Zinc Dust
+recipes.remove(<tfctech:item.Vulcanizing Agents>);
+recipes.addShapeless(<tfctech:item.Vulcanizing Agents>*4, [<ore:dustSulfur>, <ore:dustSulfur>, <ore:dustGraphite>, <ore:dustKaolinite>, <ore:dustZinc>]);
+recipes.addShapeless(<tfctech:item.Vulcanizing Agents>*4, [<ore:dustSulfur>, <ore:dustSulfur>, <ore:dustChalk>, <ore:dustKaolinite>, <ore:dustZinc>]);
+


### PR DESCRIPTION
Historically, Vulanization used mostly Sulfur with Carbon (graphite), Kaolinite, and Chalk as fillers. None of the fillers helped speed up the process of Vulcanization (which is very slow with just Sulfur), Zinc Oxide was needed to increase the speed.

This change modifies the recipes to make Sulfur as the main ingredient in the agent, and also make the player use Zinc Dust (zinc oxide) as well. The Zinc Dust can be easily obtained once the player has reached the Crusher and Macerator as those recipes already exist. This also adds recipes for the Quern that are not good as far as the amount of return of Zinc Dust.

I also wanted to make the recipe more flexible. Right now, the player has no chance at Rubber without Chalk. That is not realistic and is too limiting of a recipe. Historically, chalk was not required, but it was used alongside the Sulfur when available. There now exists a recipe that uses 2x Sulfur Dust, 1 Zinc Dust, 1 Kaolinite Dust and 1 Graphite Dust and an alternative recipe that uses 2x Sulfur Dust, 1 Zinc Dust, 1 Kaolinite Dust and 1 Chalk Powder.

To make it even more realistic (but probably not as good gameplay-wise), ONLY 1 Kaolinite or Graphite or Chalk should be used.