### PR TITLE
Change Output of IE Coke Oven to TFC Charcoal

### DIFF
--- a/scripts/IE.zs
+++ b/scripts/IE.zs
@@ -387,3 +387,7 @@ mods.immersiveengineering.Excavator.addMineral("dirt", 25, 0.3, ["blockDirt", "s
 
 //Biofuel
 mods.immersiveengineering.Refinery.removeRecipe(<liquid:biodiesel>);
+
+//Change Coal Oven Output to TFC Charcoal
+mods.immersiveengineering.CokeOven.removeRecipe(<minecraft:coal:1>);
+mods.immersiveengineering.CokeOven.addRecipe(<terrafirmacraft:item.coal:1>, 250, <ore:logWood>, 900);


### PR DESCRIPTION
* All logs cooked in the IE Coke Oven will now output TFC Charcoal instead of MC Charcoal
* Fixes the problem of using incompatible Charcoal in the Bloomery and Blast Furnace when you forget to convert it